### PR TITLE
App now called "Planet Learning" in both App Drawer and Recent Apps menu

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,14 +15,13 @@
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="@string/app_project_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/MyMaterialTheme">
         <activity
             android:name=".LoginActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
-            android:label="@string/title_activity_login">
+            android:configChanges="orientation|keyboardHidden|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Fixes #73  

App is now called "Planet Learning" in both App Drawer and Recent Apps menu.

**Screenshot 1**
![planet-learning-app-drawer-1](https://user-images.githubusercontent.com/10681719/42004055-3b8812a2-7a3c-11e8-8100-a8197076fcbf.jpg)

**Screenshot 2**
![planet-learning-app-drawer-2](https://user-images.githubusercontent.com/10681719/42004083-4e4f8262-7a3c-11e8-84da-9436eef565d4.jpg)

**Screenshot 3**
![planet-learning-app-drawer-3](https://user-images.githubusercontent.com/10681719/42066084-b25e2a6c-7b0c-11e8-8816-f7405506125e.jpg)